### PR TITLE
Fix ErrorDetail issue with connect-grpcreflect-go v1.0.0 and grpcurl

### DIFF
--- a/grpcreflect.go
+++ b/grpcreflect.go
@@ -267,7 +267,9 @@ func (r *Reflector) getAllExtensionNumbersOfType(fqn string) ([]int32, error) {
 		return true
 	})
 	if len(nums) == 0 {
-		return nil, fmt.Errorf("no extensions for type %q", fqn)
+		if _, err := r.descriptorResolver.FindDescriptorByName(name); err != nil {
+			return nil, err
+		}
 	}
 	sort.Slice(nums, func(i, j int) bool {
 		return nums[i] < nums[j]

--- a/grpcreflect_test.go
+++ b/grpcreflect_test.go
@@ -256,6 +256,32 @@ func testReflector(t *testing.T, reflector *Reflector, servicePath string) {
 			t.Fatal(diff)
 		}
 	})
+	t.Run("all_extension_numbers_of_type_find_descriptor_by_name", func(t *testing.T) {
+		const extendableFQN = "connect.reflecttest.v1.DoRequest"
+		req := &reflectionv1.ServerReflectionRequest{
+			Host: "some-host",
+			MessageRequest: &reflectionv1.ServerReflectionRequest_AllExtensionNumbersOfType{
+				AllExtensionNumbersOfType: extendableFQN,
+			},
+		}
+		res, err := call(req)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		expect := &reflectionv1.ServerReflectionResponse{
+			ValidHost:       req.Host,
+			OriginalRequest: req,
+			MessageResponse: &reflectionv1.ServerReflectionResponse_AllExtensionNumbersResponse{
+				AllExtensionNumbersResponse: &reflectionv1.ExtensionNumberResponse{
+					BaseTypeName:    extendableFQN,
+					ExtensionNumber: []int32{},
+				},
+			},
+		}
+		if diff := cmp.Diff(expect, res, protocmp.Transform()); diff != "" {
+			t.Fatal(diff)
+		}
+	})
 	t.Run("all_extension_numbers_of_type_missing", func(t *testing.T) {
 		t.Parallel()
 		req := &reflectionv1.ServerReflectionRequest{


### PR DESCRIPTION
# ErrorDetail issue with connect-grpcreflect-go v1.0.0 and grpcurl

## Problem

When starting a gRPC server using connect-grpcreflect-go v1.0.0, ErrorDetail is not displayed when an error occurs in response to a request from the client.
This problem does not occur when using google.golang.org/grpc v1.51.0.

## Difference in behavior

### With 'google.golang.org/grpc v1.51.0'
https://github.com/2yanpath/grpc-error-detail-test

```bash
% grpcurl -plaintext -d '{"name": ""}' localhost:8081 greet.v1.GreetService.Greet
ERROR:
  Code: InvalidArgument
  Message: name is required
  Details:
  1)	{"@type":"type.googleapis.com/google.rpc.BadRequest","fieldViolations":[{"field":"username","description":"should not empty"}]}
```
Expected respone

### With 'connect-go v1.7.0' and 'connect-grpcreflect-go v1.0.0'
https://github.com/2yanpath/connect-error-detail-test
branch: main

```bash
% grpcurl -plaintext -d '{"name": ""}' localhost:8082 greet.v1.GreetService.Greet
ERROR:
  Code: InvalidArgument
  Message: name is required
  Details:
  1)	{"@error":"google.rpc.BadRequest is not recognized; see @value for raw binary message data","@type":"type.googleapis.com/google.rpc.BadRequest","@value":"ChwKCHVzZXJuYW1lEhBzaG91bGQgbm90IGVtcHR5"}
```
problem: **ErrorDetail cannot be displayed.**

### [After fix] With 'connect-go v1.7.0' and 'connect-grpcreflect-go v1.0.0 based fix branch'
https://github.com/2yanpath/connect-error-detail-test
branch: fix/error-detail
```
% grpcurl -plaintext -d '{"name": ""}' localhost:8082 greet.v1.GreetService.Greet
ERROR:
  Code: InvalidArgument
  Message: name is required
  Details:
  1)	{"@type":"type.googleapis.com/google.rpc.BadRequest","fieldViolations":[{"field":"username","description":"should not empty"}]}
```

## Code difference
### google.golang.org/grpc v1.51.0

#### serverreflection.go
```go
// allExtensionNumbersForTypeName returns all extension numbers for the given type.
func (s *serverReflectionServer) allExtensionNumbersForTypeName(name string) ([]int32, error) {
	var numbers []int32
	s.extResolver.RangeExtensionsByMessage(protoreflect.FullName(name), func(xt protoreflect.ExtensionType) bool {
		numbers = append(numbers, int32(xt.TypeDescriptor().Number()))
		return true
	})
	sort.Slice(numbers, func(i, j int) bool {
		return numbers[i] < numbers[j]
	})
	if len(numbers) == 0 {
                 //-- NOTICE no error is thrown, so ([]int32{}, nil) is returned
		// maybe return an error if given type name is not known
		if _, err := s.descResolver.FindDescriptorByName(protoreflect.FullName(name)); err != nil {
			return nil, err
		}
	}
	return numbers, nil
}
```

### connect-grpcreflect-go v1.0.0

#### grpcreflect.go
```go
func (r *Reflector) getAllExtensionNumbersOfType(fqn string) ([]int32, error) {
	nums := []int32{}
	name := protoreflect.FullName(fqn)
	r.extensionResolver.RangeExtensionsByMessage(name, func(ext protoreflect.ExtensionType) bool {
		num := int32(ext.TypeDescriptor().Number())
		nums = append(nums, num)
		return true
	})
	if len(nums) == 0 {
                 //-- NOTICE an error occurs and (nil, [the error below]) is returned
		return nil, fmt.Errorf("no extensions for type %q", fqn)
	}
	sort.Slice(nums, func(i, j int) bool {
		return nums[i] < nums[j]
	})
	return nums, nil
}
```

#### [After fix] grpcreflect.go
```go
func (r *Reflector) getAllExtensionNumbersOfType(fqn string) ([]int32, error) {
	nums := []int32{}
	name := protoreflect.FullName(fqn)
	r.extensionResolver.RangeExtensionsByMessage(name, func(ext protoreflect.ExtensionType) bool {
		num := int32(ext.TypeDescriptor().Number())
		nums = append(nums, num)
		return true
	})
	if len(nums) == 0 {
		if _, err := r.descriptorResolver.FindDescriptorByName(name); err != nil {
			return nil, err
		}
	}
	sort.Slice(nums, func(i, j int) bool {
		return nums[i] < nums[j]
	})
	return nums, nil
}
```
